### PR TITLE
Simplify CRUD Calls

### DIFF
--- a/internal/acctest/resource_project_test.go
+++ b/internal/acctest/resource_project_test.go
@@ -11,6 +11,36 @@ import (
 	"github.com/paralus/cli/pkg/project"
 )
 
+// Test empty project name
+func TestAccParalusResourceEmptyProject_basic(t *testing.T) {
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccConfigPreCheck(t) },
+		Providers: testAccProviders,
+		// CheckDestroy: testAccCheckProjectResourceDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccProjectResourceConfigEmptyProject(),
+				ExpectError: regexp.MustCompile(".*name cannot be empty.*"),
+			},
+		},
+	})
+}
+
+func testAccProjectResourceConfigEmptyProject() string {
+
+	conf = paralusProviderConfig()
+	providerConfig := providerString(conf, "project_empty_name")
+	return fmt.Sprintf(`
+		%s
+
+		resource "paralus_project" "emptyname_test" {
+			provider = paralus.project_empty_name
+			name = ""
+		}
+	`, providerConfig)
+}
+
 // Test fail create project if organization name not same as UI configuration
 func TestAccParalusResourceProjectBadOrg_basic(t *testing.T) {
 


### PR DESCRIPTION
- Remove errors from read lookups and have read be where the schema updates occur
- Have get calls for project/cluster assume it doesn't exist and return quietly Add resource missing tests
- Move the bootstraping updates to the utils class so can be called by resources and datasources