### PR TITLE
Add guards against non-existent users and groups when setting access …

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ See [docs](/docs) page for a full explanation of the various datasource/resource
 
 ## Acceptance Tests
 
-Acceptance tests (deployed under the /internal/acctest directory) can be run one of two ways. 
+Acceptance tests (deployed under the /internal/acctest directory) can be run one of two ways.
 
 *Note:* Some of the tests require certain items already be setup. These are as follows:
 
@@ -32,6 +32,9 @@ Acceptance tests (deployed under the /internal/acctest directory) can be run one
         - name: acctest-user@example.com
         - first name: acctest
         - last name: user
+- New Group:
+        - name: acctest-group
+        - description: For acceptance testing
 
 ### Single Test
 
@@ -71,9 +74,9 @@ If you wish to run a specific acceptance test, do the following:
     }
     ```
 
-5. Go into the individual test case within your go file and highlight the func name
-6. Go to `Run and Debug` on the left and select `Launch a test function` from the top
-7. Look at the `DEBUG_CONSOLE` window to see the result
+4. Go into the individual test case within your go file and highlight the func name
+5. Go to `Run and Debug` on the left and select `Launch a test function` from the top
+6. Look at the `DEBUG_CONSOLE` window to see the result
 
 ### All Tests
 

--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -96,10 +96,13 @@ resource "paralus_group" "test" {
 
 Required:
 
-- `group` (String) Authorized group
 - `role` (String) Role name
 
 Optional:
 
 - `namespace` (String) Authorized namespace
 - `project` (String) Project name
+
+Read-Only:
+
+- `group` (String) Authorized group. This will always be the same as the resource group name.

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -11,7 +11,9 @@ Resource containing paralus project information. Uses the [pctl](https://github.
 
 NOTE: Due to a limitation with paralus, there cannot be more than one project_role block with the same role type. 
 Use the [Group Resource](https://registry.terraform.io/providers/iherbllc/paralus/latest/docs/resources/group) after
-creating the project to grant the same role.
+creating the project to grant the same role. 
+
+See the paralus issue [136](https://github.com/paralus/paralus/issues/136) for more information.
 
 ## Example Usage
 
@@ -104,12 +106,15 @@ resource "paralus_project" "test" {
 Required:
 
 - `group` (String) Authorized group
-- `project` (String) Project name
 - `role` (String) Role name
 
 Optional:
 
 - `namespace` (String) Authorized namespace
+
+Read-Only:
+
+- `project` (String) Project name. This will always be the same as the resource project name.
 
 
 <a id="nestedblock--user_roles"></a>

--- a/internal/acctest/resource_group_test.go
+++ b/internal/acctest/resource_group_test.go
@@ -221,7 +221,6 @@ func TestAccParalusResourceGroup_Project(t *testing.T) {
 					description = "test group"
 					project_roles {
 						role = "ADMIN"
-						group = "test"
 					}
 				}`),
 				Check: resource.ComposeTestCheckFunc(
@@ -291,7 +290,6 @@ func TestAccParalusResourceGroups_AddToProject(t *testing.T) {
 					project_roles {
 						project = paralus_project.temp.name
 						role = "PROJECT_ADMIN"
-						group = "test1"
 					}
 				}
 				resource "paralus_group" "test2" {
@@ -301,7 +299,6 @@ func TestAccParalusResourceGroups_AddToProject(t *testing.T) {
 					project_roles {
 						project = paralus_project.temp.name
 						role = "PROJECT_ADMIN"
-						group = "test2"
 					}
 				}`),
 				Check: resource.ComposeTestCheckFunc(
@@ -382,6 +379,74 @@ func TestAccParalusResourceGroup_AddUser(t *testing.T) {
 				ResourceName:      groupRsName1,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// Test adding a non-existing user to a group
+func TestAccParalusResourceGroup_AddNonExistingUser(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccConfigPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGroupResourceDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProviderValidResource(`
+				resource "paralus_group" "test" {
+					provider = paralus.valid_resource
+					name = "test1"
+					description = "test 1 group"
+					users = ["nobody@here.com"]
+				}`),
+				ExpectError: regexp.MustCompile(".*does not exist.*"),
+			},
+		},
+	})
+}
+
+// Test adding a non-existing project to a group
+func TestAccParalusResourceGroup_AddNonExistingProject(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccConfigPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGroupResourceDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProviderValidResource(`
+				resource "paralus_group" "test" {
+					provider = paralus.valid_resource
+					name = "test1"
+					description = "test 1 group"
+					project_roles {
+						role = "PROJECT_ADMIN"
+						project = "i dont exist"
+					}
+				}`),
+				ExpectError: regexp.MustCompile(".*does not exist.*"),
+			},
+		},
+	})
+}
+
+// Test requesting a project role witihout specifying a project
+func TestAccParalusResourceProject_NoProjectSpecified(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccConfigPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGroupResourceDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProviderValidResource(`
+				resource "paralus_group" "test" {
+					provider = paralus.valid_resource
+					name = "test1"
+					description = "test 1 group"
+					project_roles {
+						role = "PROJECT_ADMIN"
+					}
+				}`),
+				ExpectError: regexp.MustCompile(".*project must be specified.*"),
 			},
 		},
 	})

--- a/internal/acctest/resource_project_test.go
+++ b/internal/acctest/resource_project_test.go
@@ -207,6 +207,78 @@ func testAccCheckResourceProjectTypeAttribute(resourceName string, description s
 	}
 }
 
+// Test adding a non-existing user to a project
+func TestAccParalusResourceProject_AddNonExistingUser(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccConfigPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGroupResourceDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProviderValidResource(`
+				resource "paralus_project" "test" {
+					provider = paralus.valid_resource
+					name = "test1"
+					description = "test 1 group"
+					user_roles {
+						user = "nobody@here.com"
+						role = "PROJECT_ADMIN"
+					}
+				}`),
+				ExpectError: regexp.MustCompile(".*does not exist.*"),
+			},
+		},
+	})
+}
+
+// Test requesting an empty group name for the project roles
+func TestAccParalusResourceProject_GroupNameEmpty(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccConfigPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGroupResourceDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProviderValidResource(`
+				resource "paralus_project" "test" {
+					provider = paralus.valid_resource
+					name = "test1"
+					description = "test 1 group"
+					project_roles {
+						group = ""
+						role = "PROJECT_ADMIN"
+					}
+				}`),
+				ExpectError: regexp.MustCompile(".*cannot be empty.*"),
+			},
+		},
+	})
+}
+
+// Test adding a non-existing group to a project
+func TestAccParalusResourceProject_AddNonExistingGroup(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccConfigPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGroupResourceDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProviderValidResource(`
+				resource "paralus_project" "test" {
+					provider = paralus.valid_resource
+					name = "test1"
+					description = "test 1 group"
+					project_roles {
+						group = "does not exist"
+						role = "PROJECT_ADMIN"
+					}
+				}`),
+				ExpectError: regexp.MustCompile(".*does not exist.*"),
+			},
+		},
+	})
+}
+
 // Test creating project and adding in group
 func TestAccParalusResourceProject_AddToGroup(t *testing.T) {
 	groupRsName := "paralus_group.test"
@@ -232,7 +304,6 @@ func TestAccParalusResourceProject_AddToGroup(t *testing.T) {
 					name = "test"
 					description = "test project"
 					project_roles {
-						project = "test"
 						role = "PROJECT_READ_ONLY"
 						group = paralus_group.test.name
 					}
@@ -301,13 +372,11 @@ func TestAccParalusResourceProject_Add2GroupsNamespaceAndProjectRoles(t *testing
 					name = "test"
 					description = "test project"
 					project_roles {
-						project = "test"
 						role = "NAMESPACE_READ_ONLY"
 						namespace = "platform"
 						group = paralus_group.test1.name
 					}
 					project_roles {
-						project = "test"
 						role = "PROJECT_ADMIN"
 						group = paralus_group.test2.name
 					}
@@ -396,13 +465,11 @@ func TestAccParalusResourceProject_Add2GroupsDifferentNamespaceRoles(t *testing.
 					name = "test"
 					description = "test project"
 					project_roles {
-						project = "test"
 						role = "NAMESPACE_READ_ONLY"
 						namespace = "platform"
 						group = paralus_group.test1.name
 					}
 					project_roles {
-						project = "test"
 						role = "NAMESPACE_ADMIN"
 						namespace = "platform"
 						group = paralus_group.test2.name
@@ -494,12 +561,10 @@ func TestAccParalusResourceProject_Add2GroupsDifferentProjectRoles(t *testing.T)
 					name = "test"
 					description = "test project"
 					project_roles {
-						project = "test"
 						role = "PROJECT_READ_ONLY"
 						group = paralus_group.test1.name
 					}
 					project_roles {
-						project = "test"
 						role = "PROJECT_ADMIN"
 						group = paralus_group.test2.name
 					}
@@ -581,13 +646,11 @@ func TestAccParalusResourceProject_Add2GroupsSameNamespaceRoles(t *testing.T) {
 					description = "test project"
 					project_roles {
 						namespace = "platform"
-						project = "test"
 						role = "NAMESPACE_READ_ONLY"
 						group = paralus_group.test1.name
 					}
 					project_roles {
 						namespace = "platform"
-						project = "test"
 						role = "NAMESPACE_READ_ONLY"
 						group = paralus_group.test2.name
 					}
@@ -625,12 +688,10 @@ func TestAccParalusResourceProject_Add2GroupsSameProjectRoles(t *testing.T) {
 					name = "test"
 					description = "test project"
 					project_roles {
-						project = "test"
 						role = "PROJECT_READ_ONLY"
 						group = paralus_group.test1.name
 					}
 					project_roles {
-						project = "test"
 						role = "PROJECT_READ_ONLY"
 						group = paralus_group.test2.name
 					}

--- a/internal/utils/user_utils.go
+++ b/internal/utils/user_utils.go
@@ -1,0 +1,38 @@
+// Utility methods for PCTL User struct
+package utils
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/paralus/cli/pkg/user"
+	userv3 "github.com/paralus/paralus/proto/types/userpb/v3"
+)
+
+// Check users from a list exist in paralus
+func CheckUsersExist(users []string) diag.Diagnostics {
+	var diags diag.Diagnostics
+	if len(users) > 0 {
+		for _, usr := range users {
+			userStruct, _ := user.GetUserByName(usr)
+			if userStruct == nil {
+				return diag.FromErr(fmt.Errorf("user '%s' does not exist", usr))
+			}
+		}
+	}
+	return diags
+}
+
+// Check users from a UserRole structs exist in paralus
+func CheckUserRoleUsersExist(userRoles []*userv3.UserRole) diag.Diagnostics {
+	var diags diag.Diagnostics
+	if len(userRoles) > 0 {
+		for _, userRole := range userRoles {
+			userStruct, _ := user.GetUserByName(userRole.User)
+			if userStruct == nil {
+				return diag.FromErr(fmt.Errorf("user '%s' does not exist", userRole.User))
+			}
+		}
+	}
+	return diags
+}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/pkg/errors"
 )
 
 func MultiEnvSearch(ks []string) string {
@@ -49,8 +48,8 @@ func AssertStringNotEmpty(message, str string) diag.Diagnostics {
 	}
 
 	if message != "" {
-		return diag.FromErr(errors.New(fmt.Sprintf("%s: expected not empty string.", message)))
+		return diag.FromErr(fmt.Errorf("%s: expected not empty string", message))
 	} else {
-		return diag.FromErr(errors.New("expected not empty string."))
+		return diag.FromErr(fmt.Errorf("expected not empty string"))
 	}
 }

--- a/templates/resources/project.md.tmpl
+++ b/templates/resources/project.md.tmpl
@@ -11,7 +11,9 @@ description: |-
 
 NOTE: Due to a limitation with paralus, there cannot be more than one project_role block with the same role type. 
 Use the [Group Resource](https://registry.terraform.io/providers/iherbllc/paralus/latest/docs/resources/group) after
-creating the project to grant the same role.
+creating the project to grant the same role. 
+
+See the paralus issue [136](https://github.com/paralus/paralus/issues/136) for more information.
 
 ## Example Usage
 


### PR DESCRIPTION
…rights

Add tests for these use cases
Removed project name being set in project_roles block for project resource and group name in project_roles block for group resource since it'll always be the same. Update README and docs